### PR TITLE
fix(package): Set targets for macOS build

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -7,6 +7,8 @@ function build() {
   GOARCH="$2"
   COMMAND="$3"
 
+  GOARCH="$GOARCH" \
+  GOOS="$GOOS" \
   go build -o "$OUTDIR/$GOOS-$GOARCH/$COMMAND" "./cmd/$COMMAND"
 }
 

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -24,7 +24,7 @@ function package() {
   zip --recurse-paths "./$GOOS-$GOARCH.zip" "./$GOOS-$GOARCH/"
   popd
 
-  rm --recursive "$OUTDIR/$GOOS-$GOARCH/"
+  rm -r "$OUTDIR/$GOOS-$GOARCH/"
 }
 
 DEFAULT_OUTDIR="$(dirname "${BASH_SOURCE[0]}")/../dist"

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -7,9 +7,13 @@ function build() {
   GOARCH="$2"
   COMMAND="$3"
 
-  GOARCH="$GOARCH" \
-  GOOS="$GOOS" \
-  go build -o "$OUTDIR/$GOOS-$GOARCH/$COMMAND" "./cmd/$COMMAND"
+  (
+    export CGO_ENABLED=0
+    export GOARCH="$GOARCH"
+    export GOOS="$GOOS"
+
+    go build -o "$OUTDIR/$GOOS-$GOARCH/$COMMAND" "./cmd/$COMMAND"
+  )
 }
 
 function package() {
@@ -23,8 +27,7 @@ function package() {
   rm --recursive "$OUTDIR/$GOOS-$GOARCH/"
 }
 
-CGO_ENABLED=0
-DEFAULT_OUTDIR="$(dirname ${BASH_SOURCE[0]})/../dist"
+DEFAULT_OUTDIR="$(dirname "${BASH_SOURCE[0]}")/../dist"
 OUTDIR="${OUTDIR:-$DEFAULT_OUTDIR}"
 
 build darwin amd64 spaced


### PR DESCRIPTION
`GOARCH` and `GOOS` environment variables were not set on `go build`.