### PR TITLE
fix(code): Use strings.Builder over concatenation

### DIFF
--- a/internal/text/char.go
+++ b/internal/text/char.go
@@ -1,6 +1,7 @@
 package text
 
 import (
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -10,12 +11,14 @@ import (
 // Char represents a character. Whatever that means.
 type Char []rune
 
-func (char Char) String() (str string) {
+func (char Char) String() string {
+	var builder strings.Builder
+
 	for _, r := range char {
-		str += string(r)
+		builder.WriteRune(r)
 	}
 
-	return
+	return builder.String()
 }
 
 // SplitString splits a string into a slice of characters.

--- a/internal/text/transform/spaced.go
+++ b/internal/text/transform/spaced.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/72636c/hyperspaced/internal/text"
 )
@@ -19,23 +20,26 @@ func SpacedN(str string, n int) string {
 
 	chars := text.SplitString(str)
 	sep := toSeparator(n)
-	str = "" // lol variable reassignment
 
-	for _, char := range chars {
-		str += char.String() + sep
+	var builder strings.Builder
+
+	for index, char := range chars {
+		builder.WriteString(char.String())
+
+		if index < len(chars)-1 {
+			builder.WriteString(sep)
+		}
 	}
 
-	if len(str) == 0 {
-		return ""
-	}
-
-	return str[:len(str)-len(sep)]
+	return builder.String()
 }
 
-func toSeparator(length int) (sep string) {
+func toSeparator(length int) string {
+	var builder strings.Builder
+
 	for index := 0; index < length; index++ {
-		sep += " "
+		builder.WriteString(" ")
 	}
 
-	return
+	return builder.String()
 }


### PR DESCRIPTION
¯\\\_(ツ)\_/¯