### PR TITLE
chore(ci): Sign Drone configuration file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 kind: pipeline
 name: default
 
@@ -54,3 +55,7 @@ steps:
 volumes:
   - name: dist
     temp: {}
+
+---
+kind: signature
+hmac: 477adf6101919505d45c6ee4aa57a7259adc3d6d3112ea27281a49453ce8902c


### PR DESCRIPTION
Allow builds to run automatically when there are no (unsigned) changes to `.drone.yml`.

https://docs.drone.io/user-guide/signature/