### PR TITLE
feat(spaced): Avoid naming stutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 vendor/
 
 .DS_Store
+debug.test
 hyperspaced

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ import (
   "github.com/72636c/hyperspaced"
 )
 
-hyperspaced.Spaced("AESTHETIC")
+hyperspaced.One("AESTHETIC")
 // A E S T H E T I C
 
-hyperspaced.SpacedN("AESTHETIC", 2)
+hyperspaced.N("AESTHETIC", 2)
 // A  E  S  T  H  E  T  I  C
 ```
 

--- a/hyperspaced.go
+++ b/hyperspaced.go
@@ -6,12 +6,22 @@ import (
 	"github.com/72636c/hyperspaced/internal/text/transform"
 )
 
-// Spaced inserts a space between each character in a string.
-func Spaced(str string) string {
+// N inserts n spaces between each character in a string.
+func N(str string, n int) string {
+	return transform.SpacedN(str, n)
+}
+
+// One inserts a space between each character in a string.
+func One(str string) string {
 	return transform.Spaced(str)
 }
 
-// SpacedN inserts n spaces between each character in a string.
+// Spaced is an alias for One that is retained for backwards compatibility.
+func Spaced(str string) string {
+	return One(str)
+}
+
+// SpacedN is an alias for N that is retained for backwards compatibility.
 func SpacedN(str string, n int) string {
-	return transform.SpacedN(str, n)
+	return N(str, n)
 }

--- a/hyperspaced.go
+++ b/hyperspaced.go
@@ -6,6 +6,14 @@ import (
 	"github.com/72636c/hyperspaced/internal/text/transform"
 )
 
+var (
+	// Spaced is an alias for One that is retained for backwards compatibility.
+	Spaced = One
+
+	// SpacedN is an alias for N that is retained for backwards compatibility.
+	SpacedN = N
+)
+
 // N inserts n spaces between each character in a string.
 func N(str string, n int) string {
 	return transform.SpacedN(str, n)
@@ -14,14 +22,4 @@ func N(str string, n int) string {
 // One inserts a space between each character in a string.
 func One(str string) string {
 	return transform.Spaced(str)
-}
-
-// Spaced is an alias for One that is retained for backwards compatibility.
-func Spaced(str string) string {
-	return One(str)
-}
-
-// SpacedN is an alias for N that is retained for backwards compatibility.
-func SpacedN(str string, n int) string {
-	return N(str, n)
 }

--- a/hyperspaced_test.go
+++ b/hyperspaced_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/72636c/hyperspaced"
 )
 
-func ExampleSpaced() {
-	output := hyperspaced.Spaced("AESTHETIC")
-
-	fmt.Println(output)
-	// Output: A E S T H E T I C
-}
-
-func ExampleSpacedN() {
-	output := hyperspaced.SpacedN("AESTHETIC", 2)
+func ExampleN() {
+	output := hyperspaced.N("AESTHETIC", 2)
 
 	fmt.Println(output)
 	// Output: A  E  S  T  H  E  T  I  C
+}
+
+func ExampleOne() {
+	output := hyperspaced.One("AESTHETIC")
+
+	fmt.Println(output)
+	// Output: A E S T H E T I C
 }

--- a/internal/text/transform/spaced.go
+++ b/internal/text/transform/spaced.go
@@ -15,7 +15,7 @@ func Spaced(str string) string {
 // SpacedN inserts n spaces between each character in a string.
 func SpacedN(str string, n int) string {
 	if n < 0 {
-		panic(errors.New("hyperspaced.SpacedN: really?"))
+		panic(errors.New("hyperspaced/internal/text.SpacedN: really?"))
 	}
 
 	chars := text.SplitString(str)

--- a/internal/text/transform/spaced_test.go
+++ b/internal/text/transform/spaced_test.go
@@ -6,7 +6,69 @@ import (
 	"github.com/72636c/hyperspaced"
 )
 
-func Test_Spaced(t *testing.T) {
+func Suite_N(t *testing.T, f func(string, int) string) {
+	testCases := []struct {
+		description string
+		inputString string
+		inputN      int
+		expected    string
+	}{
+		{
+			description: "One Space",
+			inputString: "AESTHETIC",
+			inputN:      1,
+			expected:    "A E S T H E T I C",
+		},
+		{
+			description: "Two Spaces",
+			inputString: "AESTHETIC",
+			inputN:      2,
+			expected:    "A  E  S  T  H  E  T  I  C",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			actual := f(testCase.inputString, testCase.inputN)
+			if actual != testCase.expected {
+				t.Errorf(
+					"expected %+[1]q (%[1]s), received %+[2]q (%[2]s)",
+					testCase.expected,
+					actual,
+				)
+			}
+		})
+	}
+}
+
+func Suite_N_Panics_OnNegativeN(t *testing.T, f func(string, int) string) {
+	expectedMessage := "hyperspaced/internal/text.SpacedN: really?"
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("expected recovery")
+			t.FailNow()
+		}
+
+		err, ok := r.(error)
+		if !ok {
+			t.Errorf("expected error, received %T", r)
+			t.FailNow()
+		}
+
+		message := err.Error()
+		if message != expectedMessage {
+			t.Errorf("expected %s, got %s", expectedMessage, message)
+		}
+	}()
+
+	f("", -1)
+
+	t.Error("expected panic")
+}
+
+func Suite_One(t *testing.T, f func(string) string) {
 	testCases := []struct {
 		description string
 		input       string
@@ -36,7 +98,7 @@ func Test_Spaced(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			actual := hyperspaced.Spaced(testCase.input)
+			actual := f(testCase.input)
 			if actual != testCase.expected {
 				t.Errorf(
 					"expected %+[1]q (%[1]s), received %+[2]q (%[2]s)",
@@ -46,66 +108,28 @@ func Test_Spaced(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_N(t *testing.T) {
+	Suite_N(t, hyperspaced.N)
+}
+
+func Test_N_Panics_OnNegativeN(t *testing.T) {
+	Suite_N_Panics_OnNegativeN(t, hyperspaced.N)
+}
+
+func Test_One(t *testing.T) {
+	Suite_One(t, hyperspaced.One)
+}
+
+func Test_Spaced(t *testing.T) {
+	Suite_One(t, hyperspaced.Spaced)
 }
 
 func Test_SpacedN(t *testing.T) {
-	testCases := []struct {
-		description string
-		inputString string
-		inputN      int
-		expected    string
-	}{
-		{
-			description: "One Space",
-			inputString: "AESTHETIC",
-			inputN:      1,
-			expected:    "A E S T H E T I C",
-		},
-		{
-			description: "Two Spaces",
-			inputString: "AESTHETIC",
-			inputN:      2,
-			expected:    "A  E  S  T  H  E  T  I  C",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.description, func(t *testing.T) {
-			actual := hyperspaced.SpacedN(testCase.inputString, testCase.inputN)
-			if actual != testCase.expected {
-				t.Errorf(
-					"expected %+[1]q (%[1]s), received %+[2]q (%[2]s)",
-					testCase.expected,
-					actual,
-				)
-			}
-		})
-	}
+	Suite_N(t, hyperspaced.SpacedN)
 }
 
 func Test_SpacedN_Panics_OnNegativeN(t *testing.T) {
-	expectedMessage := "hyperspaced.SpacedN: really?"
-
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Error("expected recovery")
-			t.FailNow()
-		}
-
-		err, ok := r.(error)
-		if !ok {
-			t.Errorf("expected error, received %T", r)
-			t.FailNow()
-		}
-
-		message := err.Error()
-		if message != expectedMessage {
-			t.Errorf("expected %s, got %s", expectedMessage, message)
-		}
-	}()
-
-	hyperspaced.SpacedN("", -1)
-
-	t.Error("expected panic")
+	Suite_N_Panics_OnNegativeN(t, hyperspaced.SpacedN)
 }


### PR DESCRIPTION
- `hyperspaced.Spaced` -> `hyperspaced.One`
- `hyperspaced.SpacedN` -> `hyperspaced.N`
- Old function names are retained for backwards compatibility